### PR TITLE
#7-RPlayerと右側の壁との間のすきまを修正

### DIFF
--- a/SpaceWars2/functions/Player.cpp
+++ b/SpaceWars2/functions/Player.cpp
@@ -13,13 +13,13 @@ void Player::Control(){
 	Rect tmpZoon;
 
 	if(isLeft){
-		tmpZoon = Rect(0, 0, Config::Width / 2, Config::Height);
+		tmpZoon = Rect(0, 0, Config::Width / 2 + 1, Config::Height + 1);
 		if(Input::KeyD.pressed && tmpZoon.contains(Circle(posX + PLAYER_SPEED, posY, 40)))			posX += PLAYER_SPEED;
 		if(Input::KeyA.pressed && tmpZoon.contains(Circle(posX - PLAYER_SPEED, posY, 40)))			posX -= PLAYER_SPEED;
 		if(Input::KeyW.pressed && tmpZoon.contains(Circle(posX, posY - PLAYER_SPEED, 40)))			posY -= PLAYER_SPEED;
 		if(Input::KeyS.pressed && tmpZoon.contains(Circle(posX, posY + PLAYER_SPEED, 40)))			posY += PLAYER_SPEED;
 	}else{
-		tmpZoon = Rect(Config::Width/2, 0, Config::Width / 2, Config::Height);
+		tmpZoon = Rect(Config::Width/2, 0, Config::Width / 2 + 1, Config::Height + 1);
 		if(Input::KeySemicolon.pressed && tmpZoon.contains(Circle(posX + PLAYER_SPEED, posY, 40)))	posX += PLAYER_SPEED;
 		if(Input::KeyK.pressed && tmpZoon.contains(Circle(posX - PLAYER_SPEED, posY, 40)))			posX -= PLAYER_SPEED;
 		if(Input::KeyO.pressed && tmpZoon.contains(Circle(posX, posY - PLAYER_SPEED, 40)))			posY -= PLAYER_SPEED;


### PR DESCRIPTION
Issue #7
可動域矩形が1px足りていなかったのが原因で、両者の右と下の辺について同様の事象が発生していた。
1px領域を広げることで対応した。