### PR TITLE
#37-Laserが同時にチャージ出来ない

### DIFF
--- a/SpaceWars2/skills/Laser.cpp
+++ b/SpaceWars2/skills/Laser.cpp
@@ -1,6 +1,7 @@
 #include "./Laser.hpp"
 
-bool Laser::isInvoked = false;
+bool Laser::isLShooting = false;
+bool Laser::isRShooting = false;
 
 bool Laser::update() {
 	if(isCharging){
@@ -35,7 +36,7 @@ int Laser::getDamage(Circle circle){
 }
 
 bool Laser::isInvisible(){
-	if (isInvalid)   return true;
+	if (isLeft ? isLInvalid : isRInvalid) return true;
 	if (energy <= 0) return true;
 	return false;
 }

--- a/SpaceWars2/skills/Laser.hpp
+++ b/SpaceWars2/skills/Laser.hpp
@@ -9,8 +9,10 @@ private:
 	int DamageDeal = 0;
 	Vec2 *ppos;
 	bool isLeft;
-	bool isInvalid = false;
-	static bool isInvoked;
+	bool isLInvalid = false;
+	bool isRInvalid = false;
+	static bool isLShooting;
+	static bool isRShooting;
 
 	const static int CHARGE_TIME_LIMIT = 1000; // charge時間の上限
 	const static int WAITING_TIME = 100; // 実行までにかかるwaiting時間
@@ -29,13 +31,13 @@ public:
 	Laser(Vec2 *p, bool left) : Bullet(p, left) {
 		ppos = p;
 		isLeft = left;
-		if (isInvoked) { // if another instance is already created and still alive...
-			isInvalid = true; // this laser is disabled
-		} else isInvoked = true;
+		if (isLeft ? isLShooting : isRShooting) { // if another instance is already created and still alive...
+			(isLeft ? isLInvalid : isRInvalid) = true; // this laser is disabled
+		} else (isLeft ? isLShooting : isRShooting) = true;
 	}
 	~Laser() override {
-		if (!isInvalid)
-			isInvoked = false;
+		if (!(isLeft ? isLInvalid : isRInvalid))
+			(isLeft ? isLShooting : isRShooting) = false;
 	};
 
 	bool update() override;


### PR DESCRIPTION
issue: #37 
- f486fc4 Laserクラス内でチャージ判定に使う変数を、L/RPlayerで共通のものを使用していたため、別の変数を使用するようにした。