### PR TITLE
#00-utf-8でのコンパイル

### DIFF
--- a/SpaceWars2/SpaceWars2.vcxproj
+++ b/SpaceWars2/SpaceWars2.vcxproj
@@ -116,6 +116,7 @@
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
- 6cfc220 SpaceWars2.vcxprojにutf-8でコンパイルするオプションを追加した