### PR TITLE
#44-L/RPlayerをnamespaceに移動する 

### DIFF
--- a/SpaceWars2/CommonData.cpp
+++ b/SpaceWars2/CommonData.cpp
@@ -1,0 +1,6 @@
+#include "CommonData.hpp"
+
+namespace Data {
+	Player LPlayer;
+	Player RPlayer;
+};

--- a/SpaceWars2/CommonData.hpp
+++ b/SpaceWars2/CommonData.hpp
@@ -6,6 +6,11 @@
 
 
 struct CommonData {
-	Player LPlayer;
-	Player RPlayer;
+	// Player LPlayer;
+	// Player RPlayer;
+};
+
+namespace Data {
+	extern Player LPlayer;
+	extern Player RPlayer;
 };

--- a/SpaceWars2/SpaceWars2.vcxproj
+++ b/SpaceWars2/SpaceWars2.vcxproj
@@ -164,6 +164,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CommonData.cpp" />
     <ClCompile Include="functions\Debug.cpp" />
     <ClCompile Include="functions\MainSkill.cpp" />
     <ClCompile Include="functions\Player.cpp" />

--- a/SpaceWars2/SpaceWars2.vcxproj.filters
+++ b/SpaceWars2/SpaceWars2.vcxproj.filters
@@ -443,6 +443,9 @@
     <ClCompile Include="functions\Debug.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="CommonData.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommonData.hpp">

--- a/SpaceWars2/scenes/Finish.cpp
+++ b/SpaceWars2/scenes/Finish.cpp
@@ -1,11 +1,11 @@
 #include "Finish.hpp"
 
 void Finish::init() {
-	if (m_data->LPlayer.isHPRunOut() && m_data->RPlayer.isHPRunOut())
+	if (Data::LPlayer.isHPRunOut() && Data::RPlayer.isHPRunOut())
 		isDraw = true;
-	if (m_data->LPlayer.isHPRunOut())
+	if (Data::LPlayer.isHPRunOut())
 		isLeftWin = false;
-	if (m_data->RPlayer.isHPRunOut())
+	if (Data::RPlayer.isHPRunOut())
 		isLeftWin = true;
 	
 	if (isDraw)

--- a/SpaceWars2/scenes/Game.cpp
+++ b/SpaceWars2/scenes/Game.cpp
@@ -9,21 +9,21 @@ void Game::update() {
 	if (Input::KeyEnter.clicked)
 		changeScene(L"Finish", 500);
 
-	m_data->LPlayer.update(bullets);
-	m_data->RPlayer.update(bullets);
+	Data::LPlayer.update(bullets);
+	Data::RPlayer.update(bullets);
 
 
-	/*m_data->RPlayer.receiveDamage(m_data->LPlayer.UpdateMainSkill(m_data->RPlayer.circle()));
-	m_data->LPlayer.UpdateSubSkill();
-	m_data->LPlayer.UpdateSpecialSkill();
+	/*Data::RPlayer.receiveDamage(Data::LPlayer.UpdateMainSkill(Data::RPlayer.circle()));
+	Data::LPlayer.UpdateSubSkill();
+	Data::LPlayer.UpdateSpecialSkill();
 
-	m_data->LPlayer.receiveDamage(m_data->RPlayer.UpdateMainSkill(m_data->LPlayer.circle()));
-	m_data->RPlayer.UpdateSubSkill();
-	m_data->RPlayer.UpdateSpecialSkill();*/
+	Data::LPlayer.receiveDamage(Data::RPlayer.UpdateMainSkill(Data::LPlayer.circle()));
+	Data::RPlayer.UpdateSubSkill();
+	Data::RPlayer.UpdateSpecialSkill();*/
 
 	for(auto itr = bullets.begin(); itr != bullets.end();){
-		Vec2 myPos = ((**itr).isLeft ? m_data->LPlayer : m_data->RPlayer).circle().center;
-		Vec2 oppPos = ((**itr).isLeft ? m_data->RPlayer : m_data->LPlayer).circle().center;
+		Vec2 myPos = ((**itr).isLeft ? Data::LPlayer : Data::RPlayer).circle().center;
+		Vec2 oppPos = ((**itr).isLeft ? Data::RPlayer : Data::LPlayer).circle().center;
 		if((**itr).update(myPos, oppPos)){
 			delete *itr;
 			itr = bullets.erase(itr);
@@ -32,7 +32,7 @@ void Game::update() {
 		}
 	}
 
-	if(m_data->LPlayer.isHPRunOut() || m_data->RPlayer.isHPRunOut())
+	if(Data::LPlayer.isHPRunOut() || Data::RPlayer.isHPRunOut())
 		changeScene(L"Finish");
 }
 
@@ -40,18 +40,18 @@ void Game::draw() const {
 	TextureAsset(L"background").resize(Config::WIDTH, Config::HEIGHT).draw();
 	FontAsset(L"CicaR32")(L"I am game scene! Hello!").drawCenter(40, Color(L"#ffffff"));
 
-	/*m_data->LPlayer.DrawMainSkill();
-	m_data->LPlayer.DrawSubSkill();
-	m_data->LPlayer.DrawSpecialSkill();
-	m_data->RPlayer.DrawMainSkill();
-	m_data->RPlayer.DrawSubSkill();
-	m_data->RPlayer.DrawSpecialSkill();*/
+	/*Data::LPlayer.DrawMainSkill();
+	Data::LPlayer.DrawSubSkill();
+	Data::LPlayer.DrawSpecialSkill();
+	Data::RPlayer.DrawMainSkill();
+	Data::RPlayer.DrawSubSkill();
+	Data::RPlayer.DrawSpecialSkill();*/
 	for(auto bul : bullets){
 		bul->draw();
 	}
 
-	m_data->LPlayer.drawShip();
-	m_data->RPlayer.drawShip();
-	m_data->LPlayer.drawGauge();
-	m_data->RPlayer.drawGauge();
+	Data::LPlayer.drawShip();
+	Data::RPlayer.drawShip();
+	Data::LPlayer.drawGauge();
+	Data::RPlayer.drawGauge();
 }

--- a/SpaceWars2/scenes/Opening.cpp
+++ b/SpaceWars2/scenes/Opening.cpp
@@ -1,8 +1,8 @@
 #include "Opening.hpp"
 
 void Opening::init(){
-	m_data->LPlayer.init(Vec2(  80, Config::HEIGHT/2), true);  //円の半径
-	m_data->RPlayer.init(Vec2(1200, Config::HEIGHT/2), false); //Width-円の半径
+	Data::LPlayer.init(Vec2(  80, Config::HEIGHT/2), true);  //円の半径
+	Data::RPlayer.init(Vec2(1200, Config::HEIGHT/2), false); //Width-円の半径
 }
 
 void Opening::update(){

--- a/SpaceWars2/scenes/SkillSelect.cpp
+++ b/SpaceWars2/scenes/SkillSelect.cpp
@@ -9,8 +9,8 @@ void SkillSelect::update() {
 	if (Input::KeyEnter.clicked)
 		changeScene(L"Game", 500);
 
-	m_data->LPlayer.skillSelect();
-	m_data->RPlayer.skillSelect();
+	Data::LPlayer.skillSelect();
+	Data::RPlayer.skillSelect();
 
 }
 
@@ -18,11 +18,11 @@ void SkillSelect::draw() const {
 	TextureAsset(L"background").resize(Config::WIDTH, Config::HEIGHT).draw();
 	FontAsset(L"CicaR32")(L"SkillSelect").drawCenter(40, Color(L"#ffffff"));
 
-	FontAsset(L"CicaR32")(m_data->LPlayer.whatMainSkill).draw(40, 40);
-	FontAsset(L"CicaR32")(m_data->LPlayer.whatSubSkill).draw(40, 80);
-	FontAsset(L"CicaR32")(m_data->LPlayer.whatSpecialSkill).draw(40, 120);
+	FontAsset(L"CicaR32")(Data::LPlayer.whatMainSkill).draw(40, 40);
+	FontAsset(L"CicaR32")(Data::LPlayer.whatSubSkill).draw(40, 80);
+	FontAsset(L"CicaR32")(Data::LPlayer.whatSpecialSkill).draw(40, 120);
 
-	FontAsset(L"CicaR32")(m_data->RPlayer.whatMainSkill).draw(1240, 40);
-	FontAsset(L"CicaR32")(m_data->RPlayer.whatSubSkill).draw(1240, 80);
-	FontAsset(L"CicaR32")(m_data->RPlayer.whatSpecialSkill).draw(1240, 120);
+	FontAsset(L"CicaR32")(Data::RPlayer.whatMainSkill).draw(1240, 40);
+	FontAsset(L"CicaR32")(Data::RPlayer.whatSubSkill).draw(1240, 80);
+	FontAsset(L"CicaR32")(Data::RPlayer.whatSpecialSkill).draw(1240, 120);
 }


### PR DESCRIPTION
issue: #44

- 00251eb L/RPlayerを`struct CommonData`から`namespace Data`に移動

hppでグローバル変数を定義するといろいろ問題があるらしいので、
```cpp 
namespace Data {
	extern Player LPlayer;
	extern Player RPlayer;
};
```
みたいなかんじでhppでは`extern`になっています。