### PR TITLE
#70-グレネードのダメージ判定の問題

### DIFF
--- a/SpaceWars2/skills/Grenade.cpp
+++ b/SpaceWars2/skills/Grenade.cpp
@@ -24,7 +24,7 @@ int Grenade::getDamage(Circle _circle){
 		if(fuse > EXPLODE_TIMING)
 			this->explode();
 		if(fuse == EXPLODE_TIMING)
-			return (int)((EXPLODE_RADIUS - pos.distanceFrom(_circle.center)) / EXPLODE_RADIUS * 10);
+			return (int)(((EXPLODE_RADIUS + 60) - pos.distanceFrom(_circle.center)) / (EXPLODE_RADIUS + 60) * 10);
 		return 0;
 	}
 	return 0;


### PR DESCRIPTION
issue: #70 
- 4c8b8c0 当たり判定を60px分（＝プレイヤーサイズ分）広げた
備考：半径は30px