### PR TITLE
#15-SpecialSkillの中で発生していたWarningの原因を削除

### DIFF
--- a/SpaceWars2/skills/SummonPartner.cpp
+++ b/SpaceWars2/skills/SummonPartner.cpp
@@ -9,8 +9,6 @@ bool SummonPartner::update(Vec2 myPos, Vec2 oppPos) {
 	Println(LifeTime);
 	if(!(LifeTime%20)) bullets.push_back(new Shot(pos, isLeft));
 	for(auto itr = bullets.begin(); itr != bullets.end();){
-		Vec2 myPos = ((**itr).isLeft ? Data::LPlayer : Data::RPlayer).circle().center;
-		Vec2 oppPos = ((**itr).isLeft ? Data::RPlayer : Data::LPlayer).circle().center;
 		if((**itr).update(myPos, oppPos)){
 			delete *itr;
 			itr = bullets.erase(itr);


### PR DESCRIPTION
- 998c431 SummonPartnerにてoppPos, myPosの再定義によるWarningを修正した