### PR TITLE
#15-lockon内で起きていたWarningを修正

### DIFF
--- a/SpaceWars2/skills/LockOn.hpp
+++ b/SpaceWars2/skills/LockOn.hpp
@@ -5,7 +5,7 @@
 class LockOn : public Bullet {
 private:
 	int waitTime;
-	const double EXPLODE_TIMING = 30;
+	const int EXPLODE_TIMING = 30;
 	int explodeTime = EXPLODE_TIMING;
 	Circle getShape() { return Circle(pos, 150); }
 public:


### PR DESCRIPTION
- cb30122 doubleからintに変換していてWarningが起きていたが、そもそも必要のないのにdouble型で定義していたので、これを修正