### PR TITLE
#81-ホーミングが上方向にしか発射していない問題の修正

### DIFF
--- a/SpaceWars2/skills/Missile.hpp
+++ b/SpaceWars2/skills/Missile.hpp
@@ -7,8 +7,8 @@ private:
 	Circle getShape() { return Circle(pos, 8); }
 public:
 	Missile(Vec2 p, bool left) : Bullet(p, left) {
-		vel = Vec2(bulletSpeed * (left ? 1 : -1), 0);
-		vel.rotate(Radians(((System::FrameCount() % 20 == 0) ? 1 : -1) * 10.0));
+		vel = Vec2(bulletSpeed * (left ? 1 : -1), 0).rotate(Radians(Random(-5, 5)));
+		// vel.rotate(Radians(((System::FrameCount() % 20 == 0) ? 1 : -1) * 10.0));
 		/*angle += 7;
 		vel = .rotate(Radians(angle));
 	}


### PR DESCRIPTION
issue: #81
- 33a7f12 11行目`vel.rotate(Radians(((System::FrameCount() % 20 == 0) ? 1 : -1) * 10.0));
`が謎かったので削除し、ついでにベクトルの設定の際に弾がブレるようランダムで少し回転するようにした