### PR TITLE
#111-D9030以外のWarningを修正

### DIFF
--- a/SpaceWars2/skills/InversionRecovery.cpp
+++ b/SpaceWars2/skills/InversionRecovery.cpp
@@ -29,5 +29,6 @@ bool InversionRecovery::isVisible() {
 }
 
 int InversionRecovery::getDamage(Circle _circle) {
+	(void)_circle;
 	return 0;
 }

--- a/SpaceWars2/skills/JudgmentTime.cpp
+++ b/SpaceWars2/skills/JudgmentTime.cpp
@@ -8,7 +8,7 @@ bool JudgmentTime::update(Vec2 _myPos, Vec2 _oppPos){
 }
 
 void JudgmentTime::draw(){
-	Rect(Config::WIDTH, Config::HEIGHT).draw(ColorF(L"#cccccc").setAlpha(PLAYER.judgmentLife / 100.0));
+	Rect(Config::WIDTH, Config::HEIGHT).draw(ColorF(L"#cccccc").setAlpha(REVERSE_PLAYER.judgmentLife / 100.0));
 }
 
 bool JudgmentTime::isVisible() {
@@ -16,5 +16,6 @@ bool JudgmentTime::isVisible() {
 }
 
 int JudgmentTime::getDamage(Circle _circle){
+	(void)_circle;
 	return 0;
 }

--- a/SpaceWars2/skills/JudgmentTime.hpp
+++ b/SpaceWars2/skills/JudgmentTime.hpp
@@ -3,17 +3,17 @@
 #include "Bullet.hpp"
 #include "../CommonData.hpp"
 
-#define PLAYER (!isLeft ? Data::LPlayer : Data::RPlayer)
+#define REVERSE_PLAYER (!isLeft ? Data::LPlayer : Data::RPlayer)
 
 class JudgmentTime : public Bullet {
 private:
 	int lifeTime = 1;
 public:
 	JudgmentTime(Vec2 _pos, bool _isLeft) : Bullet(_pos, _isLeft) {
-		PLAYER.changeSpeed(0);
+		REVERSE_PLAYER.changeSpeed(0);
 	}
 	~JudgmentTime(){
-		PLAYER.changeSpeed(15);
+		REVERSE_PLAYER.changeSpeed(15);
 	}
 	bool update(Vec2 _myPos, Vec2 _oppPos) override;
 	void draw() override;

--- a/SpaceWars2/skills/Jump.cpp
+++ b/SpaceWars2/skills/Jump.cpp
@@ -16,5 +16,6 @@ bool Jump::isVisible() {
 }
 
 int Jump::getDamage(Circle _circle) {
+	(void)_circle;
 	return 0; // no damage
 }

--- a/SpaceWars2/skills/Shield.cpp
+++ b/SpaceWars2/skills/Shield.cpp
@@ -25,5 +25,6 @@ bool Shield::isVisible() {
 }
 
 int Shield::getDamage(Circle _circle) {
+	(void)_circle;
 	return 0; // no damage
 }


### PR DESCRIPTION
issue: #111
- [C4100](https://docs.microsoft.com/ja-jp/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100) `'_circle': 引数は関数の本体部で 1 度も参照されません。`
- [C4005](https://docs.microsoft.com/ja-jp/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005) `'PLAYER': マクロが再定義されました。`
  note: `'PLAYER' の以前の定義を確認してください`

が出ないように改善。