### PR TITLE
#114-BombがShieldに刺さらない

### DIFF
--- a/SpaceWars2/skills/Bomb.cpp
+++ b/SpaceWars2/skills/Bomb.cpp
@@ -51,7 +51,7 @@ int Bomb::getDamage(Circle _circle) {
 		vel.set(0, 0);
 		if (explosion) {
 			if (fuse == 0) {
-				return (int)((EXPLODE_RADIUS - pos.distanceFrom(_circle.center)) / EXPLODE_RADIUS * 100);
+				return 70;
 			}
 		}
 	}


### PR DESCRIPTION
- 57ff1f5 刺さらなかったから直した。原因は、Bombのダメージ判定時に(100-**機体中心**からの距離)*a としていたこと。