### PR TITLE
#115-Bombが二人同時に実行できない

### DIFF
--- a/SpaceWars2/skills/Bomb.cpp
+++ b/SpaceWars2/skills/Bomb.cpp
@@ -1,6 +1,5 @@
 #include "./Bomb.hpp"
 
-int Bomb::numberOfBomb = 0;
 int Bomb::numberOfLUsed = 0;
 int Bomb::numberOfRUsed = 0;
 

--- a/SpaceWars2/skills/Bomb.hpp
+++ b/SpaceWars2/skills/Bomb.hpp
@@ -10,7 +10,9 @@ private:
 	static int numberOfLUsed;
 	static int numberOfRUsed;
 	int BombUsed;
-	static int numberOfBomb;
+	int nowBombNumber;
+	int bulletSpeed = 20;
+	int fuse = 0;
 	const static int EXPLODE_RADIUS = 100;
 	Circle getShape() {
 		if (explosion) {
@@ -31,14 +33,7 @@ public:
 			numberOfRUsed++;
 		}
 		nowBombNumber = (isLeft ? numberOfLUsed : numberOfRUsed);
-		Println(nowBombNumber);
 	}
-	~Bomb() {
-
-	}
-	int nowBombNumber;
-	int fuse = 0;
-	int bulletSpeed = 20;
 	bool update(Vec2 _myPos, Vec2 _oppPos) override;
 	void draw() override;
 	bool isVisible() override;


### PR DESCRIPTION
- e71d556 直した。原因は、LRで共通のフラグを使用していた事。