### PR TITLE
#133-HPGraphが描画されないことがある

### DIFF
--- a/SpaceWars2/scenes/Game.cpp
+++ b/SpaceWars2/scenes/Game.cpp
@@ -474,8 +474,8 @@ void Game::drawHPGraph(int _x, int _y, const LineString& _LHPGraph, const LineSt
 
 	// HP graph
 	for (auto i : step(_LHPGraph.size() - 1)) {
-		_LHPGraph.movedBy(_x, _y - 100).line(i).draw(3, ColorF(L"#f00").setAlpha(0.5));
-		_RHPGraph.movedBy(_x, _y - 100).line(i).draw(3, ColorF(L"#00f").setAlpha(0.5));
+		_LHPGraph.line(i).movedBy(_x, _y - 100).draw(3, ColorF(L"#f00").setAlpha(0.5));
+		_RHPGraph.line(i).movedBy(_x, _y - 100).draw(3, ColorF(L"#00f").setAlpha(0.5));
 	}
 
 	// 白い枠

--- a/SpaceWars2/scenes/Game.cpp
+++ b/SpaceWars2/scenes/Game.cpp
@@ -473,8 +473,10 @@ void Game::drawHPGraph(int _x, int _y, const LineString& _LHPGraph, const LineSt
 	Line(_x, _y -  50, _x + w, _y -  50).draw(1, ColorF(L"#fff").setAlpha(0.8));
 
 	// HP graph
-	_LHPGraph.movedBy(_x, _y - 100).draw(3, ColorF(L"#f00").setAlpha(0.5));
-	_RHPGraph.movedBy(_x, _y - 100).draw(3, ColorF(L"#00f").setAlpha(0.5));
+	for (auto i : step(_LHPGraph.size() - 1)) {
+		_LHPGraph.line(i).draw(3, ColorF(L"#f00").setAlpha(0.5));
+		_RHPGraph.line(i).draw(3, ColorF(L"#00f").setAlpha(0.5));
+	}
 
 	// 白い枠
 	LineString{ { _x - 2, _y - h + 2}, { _x - 2, _y + 2 }, { _x + 270, _y + 2 } }.draw(4);

--- a/SpaceWars2/scenes/Game.cpp
+++ b/SpaceWars2/scenes/Game.cpp
@@ -474,8 +474,8 @@ void Game::drawHPGraph(int _x, int _y, const LineString& _LHPGraph, const LineSt
 
 	// HP graph
 	for (auto i : step(_LHPGraph.size() - 1)) {
-		_LHPGraph.line(i).draw(3, ColorF(L"#f00").setAlpha(0.5));
-		_RHPGraph.line(i).draw(3, ColorF(L"#00f").setAlpha(0.5));
+		_LHPGraph.movedBy(_x, _y - 100).line(i).draw(3, ColorF(L"#f00").setAlpha(0.5));
+		_RHPGraph.movedBy(_x, _y - 100).line(i).draw(3, ColorF(L"#00f").setAlpha(0.5));
 	}
 
 	// 白い枠


### PR DESCRIPTION
issue: #133

- ef7a95c `LineString::line(i)` を使って個別にLineを描画
- 28c76a0 描画位置を修正
- 9f3cdfd forのなかでLineStringをmoveすることでフリーズしていたため、Lineをmoveするように

---
Siv3Dのバグでした…
@windows-server-2003 に感謝🙏