### PR TITLE
WindowTitle変更

### DIFF
--- a/SpaceWars2/Config.hpp
+++ b/SpaceWars2/Config.hpp
@@ -8,7 +8,7 @@ namespace Config {
 	const int	 VER_NUM	= 19053123;
 
 	// タイトル
-	const String TITLE		= L"SPACE WARS 2";
+	const String TITLE		= L"SpaceWars 2";
 
 	// サイズ
 	const int32  WIDTH		= 1280;


### PR DESCRIPTION
issue: #166 

- cacf6b4 WindowTitleを`SpaceWars 2`に変更