### PR TITLE
ScreenGuidanceの画像が全滅 

### DIFF
--- a/SpaceWars2/scenes/ScreenGuidance.hpp
+++ b/SpaceWars2/scenes/ScreenGuidance.hpp
@@ -17,7 +17,7 @@ enum Stat {
 class ScreenGuidance final : public SceneManager<String,CommonData>::Scene {
 private:
 	Stat status = FULL;
-	const Texture gaugePic = Texture(Image(L"/7960").scale(1.5));
+	const Texture gaugePic = Texture(Image(L"/7320").scale(1.5));
 
 	const Array<Array<Point>> shadowPos = {
 	{ { 0, 0 }, { 0, 0 } }, // FULL


### PR DESCRIPTION
issue: #172 

- 3d866ed gauge画像のリソース番号が間違っていたのを修正

---
#163 でgauge画像のリソース番号を変更し忘れていたのが原因でした。気をつけます。