### PR TITLE
#171-skillSelectのselectingがリセットされない

### DIFF
--- a/SpaceWars2/functions/Player.cpp
+++ b/SpaceWars2/functions/Player.cpp
@@ -6,15 +6,7 @@
 
 bool Player::inJudgmentTime = false;
 
-void Player::init(Vec2 _pos, bool _isLeft){
-	initWithoutSkill(_pos, _isLeft);
-
-	whatMainSkill    = static_cast<MainSkill>(0);
-	whatSubSkill     = static_cast<SubSkill>(0);
-	whatSpecialSkill = static_cast<SpecialSkill>(0);
-}
-
-void Player::initWithoutSkill(Vec2 _pos, bool _isLeft) {
+void Player::init(Vec2 _pos, bool _isLeft) {
 	pos             = _pos;
 	isLeft          = _isLeft;
 	HP              = 1000;
@@ -40,6 +32,12 @@ void Player::initWithoutSkill(Vec2 _pos, bool _isLeft) {
 	KeyMainSkill    = KeyRepeat(isLeft, L"MainSkill");
 	KeySubSkill     = KeyRepeat(isLeft, L"SubSkill");
 	KeySpecialSkill = KeyRepeat(isLeft, L"SpecialSkill");
+}
+
+void Player::initSkill() {
+	whatMainSkill = static_cast<MainSkill>(0);
+	whatSubSkill = static_cast<SubSkill>(0);
+	whatSpecialSkill = static_cast<SpecialSkill>(0);
 }
 
 Circle Player::circle(){

--- a/SpaceWars2/functions/Player.cpp
+++ b/SpaceWars2/functions/Player.cpp
@@ -27,6 +27,7 @@ void Player::initWithoutSkill(Vec2 _pos, bool _isLeft) {
 	mainSkillCnt    = 0;
 	subSkillCnt     = 0;
 	specialSkillCnt = 0;
+	selectedType    = 0;
 
 	HPLog.clear();
 

--- a/SpaceWars2/functions/Player.hpp
+++ b/SpaceWars2/functions/Player.hpp
@@ -86,7 +86,7 @@ public:
 	void doSpacialSkill(std::vector<Bullet*>& bullets);
 
 	void init(Vec2 _pos, bool _isLeft);
-	void initWithoutSkill(Vec2 _pos, bool _isLeft);
+	void initSkill();
 	Circle circle();	// 本体Circle
 	Circle hitCircle();	// 当たり判定
 	void receiveDamage(int _damage);

--- a/SpaceWars2/scenes/SkillSelect.cpp
+++ b/SpaceWars2/scenes/SkillSelect.cpp
@@ -5,8 +5,8 @@
 bool SkillSelect::isLoaded = false;
 
 void SkillSelect::init() {
-	Data::LPlayer.initSkill();  //円の半径
-	Data::RPlayer.initSkill(); //WIDTH-円の半径
+	Data::LPlayer.init(Vec2(80, Config::HEIGHT / 2), true);  //円の半径
+	Data::RPlayer.init(Vec2(1200, Config::HEIGHT / 2), false); //WIDTH-円の半径
 
 	if (!isLoaded) {
 		for (auto i : step(7)) {

--- a/SpaceWars2/scenes/SkillSelect.cpp
+++ b/SpaceWars2/scenes/SkillSelect.cpp
@@ -5,8 +5,8 @@
 bool SkillSelect::isLoaded = false;
 
 void SkillSelect::init() {
-	Data::LPlayer.initWithoutSkill(Vec2(80, Config::HEIGHT / 2), true);  //円の半径
-	Data::RPlayer.initWithoutSkill(Vec2(1200, Config::HEIGHT / 2), false); //WIDTH-円の半径
+	Data::LPlayer.initSkill();  //円の半径
+	Data::RPlayer.initSkill(); //WIDTH-円の半径
 
 	if (!isLoaded) {
 		for (auto i : step(7)) {

--- a/SpaceWars2/scenes/Title.cpp
+++ b/SpaceWars2/scenes/Title.cpp
@@ -5,6 +5,8 @@ int Title::selecting = 0;
 void Title::init() {
 	Data::LPlayer.init(Vec2(80, Config::HEIGHT / 2), true);  //円の半径
 	Data::RPlayer.init(Vec2(1200, Config::HEIGHT / 2), false); //WIDTH-円の半径
+	Data::LPlayer.initSkill();
+	Data::RPlayer.initSkill();
 }
 
 void Title::update(){


### PR DESCRIPTION
issue: #171 

- 1fe9b15 `selectedType`をinitでリセットするように
- 04f081b `init()`と`initSkill()`に改名、整理