### PR TITLE
#197-SPの弾の大きさがおかしい

### DIFF
--- a/SpaceWars2/skills/SummonPartner.cpp
+++ b/SpaceWars2/skills/SummonPartner.cpp
@@ -8,7 +8,7 @@ bool SummonPartner::update(Vec2 myPos, Vec2 oppPos) {
 	LifeTime--;
 	if (!(LifeTime % 30)) {
 		Bullet* bul = new Grenade(shrinkVec2(pos, activeField, Rect(0, 0, Window::Width(), Window::Height())), isLeft);
-		bul->shrink(activeField);
+		if(shrinkRate!=1) bul->shrink(activeField);
 		bullets.push_back(bul);
 	}
 	for(auto itr = bullets.begin(); itr != bullets.end();){


### PR DESCRIPTION
原因：座標圧縮を行う関数を実行するときに、描画上の大きさも自動で縮小のサイズに応じて拡大させていた。また、SummonPartnerのupdateにおいて、Granadeを実行するときにSkillSelectとGameどっちでも対応できるようにとShrinkをすべてのPartnerが発射するGranadeで実行していた。